### PR TITLE
add --metadata-name as a config 

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,7 @@ running this script!  This script does not upload any photos for you.
 ## To use this script:
 
 1. Download the desired albums, or your whole collection, via Google Takeout.
-2. If your Google language settings are set to a language other than English, 
-   verify that a `metadata.json` file exists within the Takeout's album directories. 
-   You may need to rename the file for this script to find it.
+2. If your Google language settings are set to a language other than English, make sure you provide the `--metadata-name` argument to match your language. Simply look it up in your takeout folder.
 4. Add your Takeout photos or the original photos to PhotoPrism's import or originals directory.
 5. Import or index your files.
 6. Run the script in the Takeout directory alongside the albums and respond to any prompts.
@@ -37,18 +35,19 @@ Then, use grep to list the photos that couldn't be matched:
 ## Options:
 ```
 Usage: transfer-album.sh <options>
-  -a, --import-all         Import all photo albums (default)
-  -n, --album-name [name]  Specify a single album name to import
-  -d, --takeout-dir [dir]  Specify an alternate Google Takeout directory
-                           Defaults to the current working directory
-  -s, --sidecar-dir [dir]  Specify the sidecar directory (name matching only)
-  -m, --match [option]     Set the method used to match/identify photos
-                           Valid options: hash/name - Default matching: hash
-  -b, --batching [option]  Set to true/false to enable/disable batch submitting
-                           to the API. When false, photos are submitted
-                           the the API one at a time. (default: true)
-  -c, --config [file]      Specify an optional configuration file
-  -h, --help               Display this help
+  -a, --import-all            Import all photo albums (default)
+  -n, --album-name [name]     Specify a single album name to import
+  -d, --takeout-dir [dir]     Specify an alternate Google Takeout directory
+                              Defaults to the current working directory
+  -s, --sidecar-dir [dir]     Specify the sidecar directory (name matching only)
+      --metadata-name [name]  Specify the name of metadata files. Default: metadata.json
+  -m, --match [option]        Set the method used to match/identify photos
+                              Valid options: hash/name - Default matching: hash
+  -b, --batching [option]     Set to true/false to enable/disable batch submitting
+                              to the API. When false, photos are submitted
+                              the the API one at a time. (default: true)
+  -c, --config [file]         Specify an optional configuration file
+  -h, --help                  Display this help
 ```
 
 If `--album-name` is not specified, all albums will be imported.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ running this script!  This script does not upload any photos for you.
 ## To use this script:
 
 1. Download the desired albums, or your whole collection, via Google Takeout.
-2. If your Google language settings are set to a language other than English, make sure you provide the `--metadata-name` argument to match your language. Simply look it up in your takeout folder.
+2. If your Google language settings are set to a language other than English, make sure you provide the `--metadata-name name.json` argument to match your language. Simply look it up in your takeout folder.
 4. Add your Takeout photos or the original photos to PhotoPrism's import or originals directory.
 5. Import or index your files.
 6. Run the script in the Takeout directory alongside the albums and respond to any prompts.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ running this script!  This script does not upload any photos for you.
 ## To use this script:
 
 1. Download the desired albums, or your whole collection, via Google Takeout.
-2. If your Google language settings are set to a language other than English, make sure you provide the `--metadata-name name.json` argument to match your language. Simply look it up in your takeout folder.
+2. If your Google language settings are set to a language other than English, look up the filename 
+   in your Takeout and provide the `--metadata-file` argument to match your language. 
+   ie. `Metadaten.json` for German.
 4. Add your Takeout photos or the original photos to PhotoPrism's import or originals directory.
 5. Import or index your files.
 6. Run the script in the Takeout directory alongside the albums and respond to any prompts.
@@ -40,12 +42,13 @@ Usage: transfer-album.sh <options>
   -d, --takeout-dir [dir]     Specify an alternate Google Takeout directory
                               Defaults to the current working directory
   -s, --sidecar-dir [dir]     Specify the sidecar directory (name matching only)
-      --metadata-name [name]  Specify the name of metadata files. Default: metadata.json
+  -j, --metadata-file [name]  Specify the name of metadata files. Set for
+                              non-English languages. Default: metadata.json
   -m, --match [option]        Set the method used to match/identify photos
                               Valid options: hash/name - Default matching: hash
-  -b, --batching [option]     Set to true/false to enable/disable batch submitting
+  -b, --batching [option]     Set to true/false to configure batch submitting
                               to the API. When false, photos are submitted
-                              the the API one at a time. (default: true)
+                              to the API one at a time. (default: true)
   -c, --config [file]         Specify an optional configuration file
   -h, --help                  Display this help
 ```

--- a/transfer-album.sh
+++ b/transfer-album.sh
@@ -416,7 +416,7 @@ Usage: transfer-album.sh <options>
                     exit 1
                 else
                     # set the metadata filename
-                    metadataFilename="$(basename $2 .json).json"
+                    metadataFilename="$(basename "$2" .json).json"
                     echo "Using user-specified metadata file: $metadataFilename"
 
                     # Shift to the next agument

--- a/transfer-album.sh
+++ b/transfer-album.sh
@@ -484,6 +484,9 @@ fi
 if [ -z "$matching" ]; then
     matching="hash"
 fi
+if [ -z "$metadataFilename" ]; then
+    metadataFilename="metadata.json"
+fi
 
 # Prompt user for input if necessary
 if [ -z "$siteURL" ]; then

--- a/transfer-album.sh
+++ b/transfer-album.sh
@@ -163,10 +163,10 @@ function process_batch() {
 # Import a Google Takeout album
 function import_album() {
     albumDir="$1"
-    metadataFile="$albumDir/$metadataName"
+    metadataFile="$albumDir/$metadataFilename"
 
     if [ ! -f "$metadataFile" ]; then
-        echo -e "\nSkipping folder \"$albumDir\"; no $metadataName, does not appear to be an album."
+        echo -e "\nSkipping folder \"$albumDir\"; no $metadataFilename, does not appear to be an album."
         return
     fi
 
@@ -261,7 +261,7 @@ function import_album() {
         echo "Searching jsons..."
         for jsonFile in "$albumDir"/**/*.json; do
             # Don't try to add metadata files
-            if [ "$(basename "$jsonFile")" = $metadataName ]; then
+            if [ "$(basename "$jsonFile")" = "$metadataFilename" ]; then
                 continue
             fi
             # Get the photo title (filename) from the google json file
@@ -343,19 +343,20 @@ By default, matched photos are batched for bulk submission to the API.
 If this causes problems, see --batching below to disable it.
 
 Usage: transfer-album.sh <options>
-  -a, --import-all              Import all photo albums (default)
-  -n, --album-name [name]       Specify a single album name to import
-  -d, --takeout-dir [dir]       Specify an alternate Google Takeout directory
-                                Defaults to the current working directory
-  -s, --sidecar-dir [dir]       Specify the sidecar directory (name matching only)
-      --metadata-name [name]    Specify the name of metadata files. Default: metadata.json
-  -m, --match [option]          Set the method used to match/identify photos
-                                Valid options: hash/name - Default matching: hash
-  -b, --batching [option]       Set to true/false to enable/disable batch submitting
-                                to the API. When false, photos are submitted
-                                to the API one at a time. (default: true)
-  -c, --config [file]           Specify an optional configuration file
-  -h, --help                    Display this help
+  -a, --import-all            Import all photo albums (default)
+  -n, --album-name [name]     Specify a single album name to import
+  -d, --takeout-dir [dir]     Specify an alternate Google Takeout directory
+                              Defaults to the current working directory
+  -s, --sidecar-dir [dir]     Specify the sidecar directory (name matching only)
+  -j, --metadata-file [name]  Specify the name of metadata files. Set for
+                              non-English languages. Default: metadata.json
+  -m, --match [option]        Set the method used to match/identify photos
+                              Valid options: hash/name - Default matching: hash
+  -b, --batching [option]     Set to true/false to configure batch submitting
+                              to the API. When false, photos are submitted
+                              to the API one at a time. (default: true)
+  -c, --config [file]         Specify an optional configuration file
+  -h, --help                  Display this help
 "
                 exit 0
                 ;;
@@ -409,6 +410,19 @@ Usage: transfer-album.sh <options>
                     shift 2
                 fi
                 ;;
+            --metadata-file | -j )
+                if [ -z "$2" ]; then
+                    echo "Usage: transfer-album $1 metadata.json" >&2
+                    exit 1
+                else
+                    # set the metadata filename
+                    metadataFilename="$(basename $2 .json).json"
+                    echo "Using user-specified metadata file: $metadataFilename"
+
+                    # Shift to the next agument
+                    shift 2
+                fi
+                ;;
             --match | -m )
                 if [ -z "$2" ]; then
                     echo "Usage: transfer-album $1 [hash/name]" >&2
@@ -452,21 +466,6 @@ Usage: transfer-album.sh <options>
                     siteURL="$SITE_URL"
 
                     # Shift to the next argument
-                    shift 2
-                fi
-                ;;
-            --metadata-name )
-                if [ -z "$2" ]; then
-                    echo "Usage: transfer-album $1 metadata.json" >&2
-                    exit 1
-                elif [[ "$2" != *json ]]; then
-                    echo "Metadata filename must have extension '.json'" >&2
-                    exit 1
-                else
-                    # set the metadata filename
-                    metadataName="$2"
-
-                    # Shift to the next agument
                     shift 2
                 fi
                 ;;
@@ -558,7 +557,7 @@ if [ -n "$specifiedAlbum" ]; then
             import_album "$foundAlbum"
         fi
     fi
-elif [ -f $metadataName ]; then
+elif [ -f "$metadataFilename" ]; then
     # If we are being run from an album directory, just import this album
     echo "\"$importDirectory\" appears to be an album; importing in single album mode..."
     import_album "$importDirectory"

--- a/transfer-album.sh
+++ b/transfer-album.sh
@@ -343,18 +343,19 @@ By default, matched photos are batched for bulk submission to the API.
 If this causes problems, see --batching below to disable it.
 
 Usage: transfer-album.sh <options>
-  -a, --import-all         Import all photo albums (default)
-  -n, --album-name [name]  Specify a single album name to import
-  -d, --takeout-dir [dir]  Specify an alternate Google Takeout directory
-                           Defaults to the current working directory
-  -s, --sidecar-dir [dir]  Specify the sidecar directory (name matching only)
-  -m, --match [option]     Set the method used to match/identify photos
-                           Valid options: hash/name - Default matching: hash
-  -b, --batching [option]  Set to true/false to enable/disable batch submitting
-                           to the API. When false, photos are submitted
-                           to the API one at a time. (default: true)
-  -c, --config [file]      Specify an optional configuration file
-  -h, --help               Display this help
+  -a, --import-all              Import all photo albums (default)
+  -n, --album-name [name]       Specify a single album name to import
+  -d, --takeout-dir [dir]       Specify an alternate Google Takeout directory
+                                Defaults to the current working directory
+  -s, --sidecar-dir [dir]       Specify the sidecar directory (name matching only)
+      --metadata-name [name]    Specify the name of metadata files. Default: metadata.json
+  -m, --match [option]          Set the method used to match/identify photos
+                                Valid options: hash/name - Default matching: hash
+  -b, --batching [option]       Set to true/false to enable/disable batch submitting
+                                to the API. When false, photos are submitted
+                                to the API one at a time. (default: true)
+  -c, --config [file]           Specify an optional configuration file
+  -h, --help                    Display this help
 "
                 exit 0
                 ;;

--- a/transfer-album.sh
+++ b/transfer-album.sh
@@ -163,10 +163,10 @@ function process_batch() {
 # Import a Google Takeout album
 function import_album() {
     albumDir="$1"
-    metadataFile="$albumDir/metadata.json"
+    metadataFile="$albumDir/$metadataName"
 
     if [ ! -f "$metadataFile" ]; then
-        echo -e "\nSkipping folder \"$albumDir\"; no metadata.json, does not appear to be an album."
+        echo -e "\nSkipping folder \"$albumDir\"; no $metadataName, does not appear to be an album."
         return
     fi
 
@@ -261,7 +261,7 @@ function import_album() {
         echo "Searching jsons..."
         for jsonFile in "$albumDir"/**/*.json; do
             # Don't try to add metadata files
-            if [ "$(basename "$jsonFile")" = "metadata.json" ]; then
+            if [ "$(basename "$jsonFile")" = $metadataName ]; then
                 continue
             fi
             # Get the photo title (filename) from the google json file
@@ -352,7 +352,7 @@ Usage: transfer-album.sh <options>
                            Valid options: hash/name - Default matching: hash
   -b, --batching [option]  Set to true/false to enable/disable batch submitting
                            to the API. When false, photos are submitted
-                           the the API one at a time. (default: true)
+                           to the API one at a time. (default: true)
   -c, --config [file]      Specify an optional configuration file
   -h, --help               Display this help
 "
@@ -454,6 +454,21 @@ Usage: transfer-album.sh <options>
                     shift 2
                 fi
                 ;;
+            --metadata-name )
+                if [ -z "$2" ]; then
+                    echo "Usage: transfer-album $1 metadata.json" >&2
+                    exit 1
+                elif [[ "$2" != *json ]]; then
+                    echo "Metadata filename must have extension '.json'" >&2
+                    exit 1
+                else
+                    # set the metadata filename
+                    metadataName="$2"
+
+                    # Shift to the next agument
+                    shift 2
+                fi
+                ;;
             * )
                 echo -e "Invalid option '$1'\nUse -h for help" >&2
                 exit 0
@@ -542,7 +557,7 @@ if [ -n "$specifiedAlbum" ]; then
             import_album "$foundAlbum"
         fi
     fi
-elif [ -f "metadata.json" ]; then
+elif [ -f $metadataName ]; then
     # If we are being run from an album directory, just import this album
     echo "\"$importDirectory\" appears to be an album; importing in single album mode..."
     import_album "$importDirectory"


### PR DESCRIPTION
I have my google account set to non-english, hence the `metadata.json` is called differently.

Thus, I added the `--metadata-name [name]` option to specify it, in order not to rename hundreds of files manually (or by script).

I tested this on my takeout data and it works like charm :-) 